### PR TITLE
Update flutter_lock_screen.dart

### DIFF
--- a/lib/flutter_lock_screen.dart
+++ b/lib/flutter_lock_screen.dart
@@ -235,7 +235,6 @@ class _LockScreenState extends State<LockScreen> {
                                     widget.fingerPrintImage,
                                     height: 40,
                                     width: 40,
-                                    color: Colors.white,
                                   ),
                                 ),
                               )


### PR DESCRIPTION
Fixed issue with display of "fingerPrintImage" currently the white colour overlay the image so the image won't display.

Please accept it , it will waste other people time as well to find out the reason